### PR TITLE
Commented out lines 4,5,6

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -1,6 +1,6 @@
 # Always use https for secure connections
 # Replace 'www.example.com' with your domain name
 # (as it appears on your SSL certificate)
-RewriteEngine On
-RewriteCond %{SERVER_PORT} 80
-RewriteRule ^(.*)$ https://tldrsales.com/$1 [R=301,L]
+#RewriteEngine On
+#RewriteCond %{SERVER_PORT} 80
+#RewriteRule ^(.*)$ https://tldrsales.com/$1 [R=301,L]


### PR DESCRIPTION
Commented out these lines because I think they were causing my site to point to a ERROR 500 and where not allowing me to access my wp-admin access login.  What's interesting is that I commented out the lines in y htaccess file and my site still redirects to the SSL version of the website.